### PR TITLE
Update occurrences of '--modules' to '--modulepath'

### DIFF
--- a/5-writing-tasks/README.md
+++ b/5-writing-tasks/README.md
@@ -109,7 +109,7 @@ else:
 We can then run the task against our nodes like so:
 
 ```
-$ bolt task run exercise5::gethost host=google.com --nodes <nodes> --modules ./modules
+$ bolt task run exercise5::gethost host=google.com --nodes <nodes> --modulepath ./modules
 node1:
 
 google.com is available at 216.58.204.14 on node1

--- a/6-downloading-and-running-existing-tasks/README.md
+++ b/6-downloading-and-running-existing-tasks/README.md
@@ -67,7 +67,7 @@ wget https://raw.githubusercontent.com/puppetlabs/tasks-hands-on-lab/master/6-do
 Let's quickly check on the status of a specific package using `bolt`:
 
 ```
-bolt task run package action=status package=bash --nodes <nodes> --modules ./modules
+bolt task run package action=status package=bash --nodes <nodes> --modulepath ./modules
 node1:
 
 {"status":"up to date","version":"4.3-7ubuntu1.7"}
@@ -80,7 +80,7 @@ Ran on 1 node in 3.81 seconds
 The package task also supports other actions, including ensuring a package is installed. Let's install a package across all of our nodes using that action:
 
 ```
-bolt task run package action=install package=vim --nodes <nodes> --modules ./modules
+bolt task run package action=install package=vim --nodes <nodes> --modulepath ./modules
 node1:
 
 {"status":"installed","version":"2:7.4.052-1ubuntu3.1"}

--- a/7-writing-plans/README.md
+++ b/7-writing-plans/README.md
@@ -38,7 +38,7 @@ plan exercise7::command(String $nodes) {
 We can run the plan like so:
 
 ```
-$ bolt plan run exercise7::command nodes=<nodes> --modules ./modules
+$ bolt plan run exercise7::command nodes=<nodes> --modulepath ./modules
  11:17:39 up 19:57,  0 users,  load average: 0.14, 0.04, 0.01
 ```
 
@@ -74,7 +74,7 @@ This task simply accepts a filename and some content and saves a file to `/tmp`.
 You can run the task directly with the following command:
 
 ```
-bolt task run exercise7::write filename=hello message=world --nodes=<nodes> --modules ./modules --debug
+bolt task run exercise7::write filename=hello message=world --nodes=<nodes> --modulepath ./modules --debug
 ```
 
 Note that in this case the task doesn't output anything to stdout. It can be useful to still trace the running of the task, and for that the `--debug` flag is useful. Here is the output when run with debug:
@@ -130,7 +130,7 @@ Note that:
 You can run the plan using the following command:
 
 ```
-bolt plan run exercise7::writeread filename=hello message=world nodes=<nodes> --modules ./modules
+bolt plan run exercise7::writeread filename=hello message=world nodes=<nodes> --modulepath ./modules
 ```
 
 Note:

--- a/8-writing-advanced-plans/README.md
+++ b/8-writing-advanced-plans/README.md
@@ -62,7 +62,7 @@ In the above plan we:
 You can see this plan in action by running:
 
 ```bash
-bolt plan run exercise8::yesorno nodes=<nodes> --modules ./modules
+bolt plan run exercise8::yesorno nodes=<nodes> --modulepath ./modules
 ```
 
 When run you should see output like the following. Running it multiple times should result in different output, as the return value of the task is random the command should run on a different subset of nodes each time.


### PR DESCRIPTION
Since Bolt 0.6.0, the `--modules` command line argument has changed to `--modulepath` to indicate that in can accept a colon-separated list of directories, akin to the rest of the puppet commands.

The previous set of changes in #22 got many but not all of these.