### PR TITLE
(BOLT-1103) Add note about builtin tasks requiring the agent

### DIFF
--- a/06-downloading-and-running-existing-tasks/README.md
+++ b/06-downloading-and-running-existing-tasks/README.md
@@ -75,6 +75,8 @@ The result:
 
 # View and use parameters for a specific task
 
+**Note**: All other built in tasks currently rely on the puppet agent being installed on the remote target. We're working on removing this dependency. For now ensure that the task above to install agents ran successfully before proceeding.
+
 1. Run `bolt task show package` to view the parameters that the package task uses. 
 
     ```


### PR DESCRIPTION
This adds a note to exercise 6 around ensuring that the agent is installed on remote targets before running built in tasks. Users have run into issues trying to run built-in tasks on nodes that don't have an agent installed, so this will warn users that the built in tasks won't work unless the agent is installed. This is a temporary notice until the package and service tasks don't require the agent.