### PR TITLE
The python JSON module that ships with RHEL5 and its python 2.4 does …

### DIFF
--- a/08-writing-advanced-tasks/modules/exercise8/tasks/great_metadata.py
+++ b/08-writing-advanced-tasks/modules/exercise8/tasks/great_metadata.py
@@ -6,8 +6,12 @@ return a JSON string with a parameters key containing objects that describe
 the parameters passed by the user.
 """
 
-import json
 import sys
+
+if sys.version_info[0] == 2 and sys.version_info[1] < 5:
+    import simplejson as json
+else:
+    import json
 
 def make_serializable(object):
   if sys.version_info[0] > 2:

--- a/09-writing-advanced-plans/modules/exercise9/tasks/yesorno.py
+++ b/09-writing-advanced-plans/modules/exercise9/tasks/yesorno.py
@@ -6,7 +6,11 @@ has a boolean value. It should flip between returning true and false
 at random
 """
 
-import json
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] < 5:
+  import simplejson as json
+else:
+  import json
 import random
 
 print(json.dumps({'answer': bool(random.getrandbits(1))}))


### PR DESCRIPTION
The python JSON module that ships with RHEL5 and its python 2.4 does not contain the methods called in the lab examples. Using simplejson instead.

Running the task code as is on a RHEL5 endpoint gets you the error:

  The task failed with exit code 1:
  Traceback (most recent call last):
    File "/tmp/e362e20c-f3df-4bad-a2a8-fdb9c633a6c4/great_metadata.py", line 20, in ?
      data = json.load(sys.stdin)
  AttributeError: 'module' object has no attribute 'load'

Tested my change on RHEL5, RHEL6 and RHEL7 using the stock version of python on each.